### PR TITLE
Add anomaly detection score support

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -833,6 +833,25 @@ EL::StatusCode BasicEventSelection :: execute ()
 
   }
 
+  //---------------------------------------------------------------------------
+  // Apply lumiblock range cut if requested
+  //---------------------------------------------------------------------------
+  if ( m_lumiBlockMin > -1 ) {
+    std::cout << "starting lumi block cut" << std::endl;
+    if ( eventInfo->lumiBlock() < m_lumiBlockMin ) {
+      std::cout << "lumi block too low" << std::endl;
+      wk()->skipEvent();
+      return EL::StatusCode::SUCCESS;
+    }
+  }
+  if ( m_lumiBlockMax > -1 ) {
+    if ( eventInfo->lumiBlock() > m_lumiBlockMax ) {
+      std::cout << "lumi block too high" << std::endl;
+      wk()->skipEvent();
+      return EL::StatusCode::SUCCESS;
+    }
+  }
+
   //------------------------------------------------------------------------------------------
   // Update Pile-Up Reweighting
   //------------------------------------------------------------------------------------------
@@ -1011,6 +1030,8 @@ EL::StatusCode BasicEventSelection :: execute ()
     // save passed triggers in eventInfo
     //
     if ( m_storeTrigDecisions ) {
+
+      auto triggerChainGroup = m_trigDecTool_handle->getChainGroup(".*");
 
       std::vector<std::string>  passedTriggers;
       std::vector<std::string>  disabledTriggers;

--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -120,10 +120,10 @@ void EventInfo::setTree(TTree *tree)
     HelperFunctions::connectBranch<float>("caloCluster", tree, "e",   &m_caloCluster_e_addr   );
   }
 
-  if ( m_infoSwitch.m_anomDet ) {
-    std::vector<float>* m_adScore_addr = &m_adScore;
-    HelperFunctions::connectBranch<float>("anomDet", tree, "adScore", &m_adScore_addr );
-  }
+  // if ( m_infoSwitch.m_anomDet ) {
+  //   std::vector<float>* m_anomDet_adScore_addr = &m_anomDet_adScore;
+  //   HelperFunctions::connectBranch<float>("anomDet", tree, "adScore", &m_anomDet_adScore_addr );
+  // }
 
   if ( m_infoSwitch.m_beamspotweight ) {
     connectBranch<float>(tree, "beamSpotWeight",                    &m_beamspotweight);
@@ -224,7 +224,7 @@ void EventInfo::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_anomDet ) {
-    tree->Branch("anomDet_adScore", &m_adScore);
+    tree->Branch("anomDet_adScore", &m_anomDet_adScore);
   }
 
   if ( m_infoSwitch.m_beamspotweight ) {
@@ -287,7 +287,7 @@ void EventInfo::clear()
   }
 
   if ( m_infoSwitch.m_anomDet ) {
-    m_adScore.clear();
+    m_anomDet_adScore.clear();
   }
 
   if ( m_infoSwitch.m_beamspotweight ) {
@@ -449,13 +449,15 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event
   }
 
   if ( m_infoSwitch.m_anomDet && event ) {
+    m_anomDet_adScore.clear();
     const xAOD::TrigCompositeContainer* adCont = nullptr;
     HelperFunctions::retrieve( adCont, "HLT_AnomDet_ComboHypo", event, 0 );
     if ( adCont ) {
-      static SG::AuxElement::ConstAccessor< std::vector<float> > acc_adScore("adScore");
+      static SG::AuxElement::ConstAccessor< float > acc_adScore("adScore");
       for ( const auto comp : *adCont ) {
         if ( acc_adScore.isAvailable( *comp ) ) {
-          for ( const auto& val : acc_adScore( *comp ) ) m_adScore.push_back( val );
+          //for ( const auto& val : acc_adScore( *comp ) ) m_anomDet_adScore.push_back( val );
+          m_anomDet_adScore.push_back( acc_adScore( *comp ) );
         }
       }
     }

--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -4,6 +4,7 @@
 #include "xAODTruth/TruthEventContainer.h"
 #include "xAODEventShape/EventShape.h"
 #include "xAODCaloEvent/CaloClusterContainer.h"
+#include "xAODTrigger/TrigCompositeContainer.h"
 
 
 using namespace xAH;
@@ -119,6 +120,11 @@ void EventInfo::setTree(TTree *tree)
     HelperFunctions::connectBranch<float>("caloCluster", tree, "e",   &m_caloCluster_e_addr   );
   }
 
+  if ( m_infoSwitch.m_anomDet ) {
+    std::vector<float>* m_adScore_addr = &m_adScore;
+    HelperFunctions::connectBranch<float>("anomDet", tree, "adScore", &m_adScore_addr );
+  }
+
   if ( m_infoSwitch.m_beamspotweight ) {
     connectBranch<float>(tree, "beamSpotWeight",                    &m_beamspotweight);
   }
@@ -217,6 +223,10 @@ void EventInfo::setBranches(TTree *tree)
     tree->Branch("caloCluster_e",   &m_caloCluster_e);
   }
 
+  if ( m_infoSwitch.m_anomDet ) {
+    tree->Branch("anomDet_adScore", &m_adScore);
+  }
+
   if ( m_infoSwitch.m_beamspotweight ) {
     tree->Branch("beamSpotWeight",   &m_beamspotweight);
   }
@@ -274,6 +284,10 @@ void EventInfo::clear()
     m_caloCluster_eta.clear();
     m_caloCluster_phi.clear();
     m_caloCluster_e.clear();
+  }
+
+  if ( m_infoSwitch.m_anomDet ) {
+    m_adScore.clear();
   }
 
   if ( m_infoSwitch.m_beamspotweight ) {
@@ -431,6 +445,19 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event
       m_caloCluster_eta.push_back( clus->eta( xAOD::CaloCluster::State::UNCALIBRATED ) );
       m_caloCluster_phi.push_back( clus->phi( xAOD::CaloCluster::State::UNCALIBRATED ) );
       m_caloCluster_e.  push_back( clus->e  ( xAOD::CaloCluster::State::UNCALIBRATED ) / m_units );
+    }
+  }
+
+  if ( m_infoSwitch.m_anomDet && event ) {
+    const xAOD::TrigCompositeContainer* adCont = nullptr;
+    HelperFunctions::retrieve( adCont, "HLT_AnomDet_ComboHypo", event, 0 );
+    if ( adCont ) {
+      static SG::AuxElement::ConstAccessor< std::vector<float> > acc_adScore("adScore");
+      for ( const auto comp : *adCont ) {
+        if ( acc_adScore.isAvailable( *comp ) ) {
+          for ( const auto& val : acc_adScore( *comp ) ) m_adScore.push_back( val );
+        }
+      }
     }
   }
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -152,9 +152,10 @@ namespace HelperClasses{
     m_shapeLC       = has_exact("shapeLC");
     m_truth         = has_exact("truth");
     m_caloClus      = has_exact("caloClusters");
-    m_weightsSys    = has_exact("weightsSys");
-    m_beamspotweight= has_exact("beamspotweight");
-  }
+  m_weightsSys    = has_exact("weightsSys");
+  m_beamspotweight= has_exact("beamspotweight");
+  m_anomDet       = has_exact("anomDet");
+}
 
   void TriggerInfoSwitch::initialize(){
     m_basic             = has_exact("basic");

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -142,6 +142,11 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Calculate distance to nearest empty and unpaired BCIDs
     bool m_calcBCIDInfo = false;
 
+    /// @brief Minimum lumiblock number to accept (inclusive). Set to -1 to disable.
+    int m_lumiBlockMin = -1;
+    /// @brief Maximum lumiblock number to accept (inclusive). Set to -1 to disable.
+    int m_lumiBlockMax = -1;
+
     // Primary Vertex
     /// @brief Enable to apply a primary vertex cut
     bool m_applyPrimaryVertexCut = false;

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -100,7 +100,7 @@ namespace xAH {
     std::vector<float> m_caloCluster_e;
 
     // anomaly detection score
-    std::vector<float> m_adScore;
+    std::vector<float> m_anomDet_adScore;
 
   };
 

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -99,6 +99,9 @@ namespace xAH {
     std::vector<float> m_caloCluster_phi;
     std::vector<float> m_caloCluster_e;
 
+    // anomaly detection score
+    std::vector<float> m_adScore;
+
   };
 
   template <typename T_BR> void EventInfo::connectBranch(TTree *tree, std::string name, T_BR *variable)

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -147,6 +147,7 @@ namespace HelperClasses {
         m_caloClus       caloClusters   exact
         m_weightsSys     weightsSys     exact
         m_beamspotweight beamspotweight exact
+        m_anomDet        anomDet        exact
         ================ ============== =======
 
     @endrst
@@ -165,6 +166,7 @@ namespace HelperClasses {
     bool m_caloClus;
     bool m_weightsSys;
     bool m_beamspotweight;
+    bool m_anomDet;
     EventInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();


### PR DESCRIPTION
## Summary
- allow EventInfoSwitch to select `anomDet`
- store anomaly-detection scores when requested

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68826140b1ac8326934bb2831ce79098