### PR TITLE
Add ID WPs for electrons and photons

### DIFF
--- a/Root/ElectronDecorator.cxx
+++ b/Root/ElectronDecorator.cxx
@@ -1,0 +1,107 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+#include "xAODEgamma/ElectronContainer.h"
+#include "xAODEventInfo/EventInfo.h"
+#include "xAODAnaHelpers/HelperFunctions.h"
+#include <xAODAnaHelpers/ElectronDecorator.h>
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(ElectronDecorator)
+
+ElectronDecorator :: ElectronDecorator () :
+    Algorithm("ElectronDecorator")
+{
+}
+
+EL::StatusCode ElectronDecorator :: setupJob (EL::Job& job)
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode ElectronDecorator :: histInitialize ()
+{
+
+  ANA_MSG_INFO( m_name );
+  ANA_CHECK( xAH::Algorithm::algInitialize());
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode ElectronDecorator :: fileExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode ElectronDecorator :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
+
+EL::StatusCode ElectronDecorator :: initialize ()
+{
+  ANA_MSG_INFO( "ElectronDecorator");
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+  // needed here and not in initalize since this is called first
+  if( m_inContainerName.empty() || m_detailStr.empty() ){
+    ANA_MSG_WARNING( "One or more required configuration values are empty");
+  }
+  if (m_electronLLHToolVeryLoose.empty()) {
+    m_electronLLHToolVeryLoose.setTypeAndName("AsgElectronLikelihoodTool/ElectronLikelihoodToolVeryLoose");
+    ANA_CHECK( m_electronLLHToolVeryLoose.setProperty( "ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/ElectronLikelihoodVeryLooseTriggerConfig.conf" ));
+  }
+  ANA_CHECK( m_electronLLHToolVeryLoose.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_electronLLHToolVeryLoose);
+  if (m_electronLLHToolLoose.empty()) {
+    m_electronLLHToolLoose.setTypeAndName("AsgElectronLikelihoodTool/ElectronLikelihoodToolLoose");
+    ANA_CHECK( m_electronLLHToolLoose.setProperty( "ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/ElectronLikelihoodLooseTriggerConfig.conf" ));
+  }
+  ANA_CHECK( m_electronLLHToolLoose.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_electronLLHToolLoose);
+  if (m_electronLLHToolMedium.empty()) {
+    m_electronLLHToolMedium.setTypeAndName("AsgElectronLikelihoodTool/ElectronLikelihoodToolMedium");
+    ANA_CHECK( m_electronLLHToolMedium.setProperty( "ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/ElectronLikelihoodMediumTriggerConfig.conf" ));
+  }
+  ANA_CHECK( m_electronLLHToolMedium.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_electronLLHToolMedium);
+  if (m_electronLLHToolTight.empty()) {
+    m_electronLLHToolTight.setTypeAndName("AsgElectronLikelihoodTool/ElectronLikelihoodToolTight");
+    ANA_CHECK( m_electronLLHToolTight.setProperty( "ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/ElectronLikelihoodTightTriggerConfig.conf" ));
+  }
+  ANA_CHECK( m_electronLLHToolTight.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_electronLLHToolTight);
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode ElectronDecorator :: execute ()
+{
+   const xAOD::ElectronContainer* electrons(nullptr);
+  if (!m_inContainerName.empty()) {
+    ANA_CHECK( HelperFunctions::retrieve(electrons, m_inContainerName, m_event, m_store, msg()) );
+  }
+  static SG::AuxElement::Decorator< char > isLHVeryLoose ("LHVeryLoose");
+  static SG::AuxElement::Decorator< char > isLHLoose ("LHLoose");
+  static SG::AuxElement::Decorator< char > isLHMedium ("LHMedium");
+  static SG::AuxElement::Decorator< char > isLHTight ("LHTight");
+  for (const auto& el : *electrons) {
+    bool passLHVeryLoose = bool(m_electronLLHToolVeryLoose->accept(el));
+    isLHVeryLoose(*el) = passLHVeryLoose ? 1 : 0;
+    bool passLHLoose = bool(m_electronLLHToolLoose->accept(el));
+    isLHLoose(*el) = passLHLoose ? 1 : 0;
+    bool passLHMedium = bool(m_electronLLHToolMedium->accept(el));
+    isLHMedium(*el) = passLHMedium ? 1 : 0;
+    bool passLHTight = bool(m_electronLLHToolTight->accept(el));
+    isLHTight(*el) = passLHTight ? 1 : 0;
+    ANA_MSG_DEBUG("Electron " << el->index()
+      << " passes LHVeryLoose: " << passLHVeryLoose
+      << ", LHLoose: " << passLHLoose 
+      << ", LHMedium: " << passLHMedium
+      << ", LHTight: " << passLHTight 
+    );
+  }
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode ElectronDecorator :: postExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode ElectronDecorator :: finalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode ElectronDecorator :: histFinalize ()
+{
+  // clean up memory
+  ANA_CHECK( xAH::Algorithm::algFinalize());
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -57,6 +57,11 @@
 #include <xAODAnaHelpers/MessagePrinterAlgo.h>
 #include <xAODAnaHelpers/MuonInFatJetCorrector.h>
 
+/* Custom Decorators */
+#include <xAODAnaHelpers/ElectronDecorator.h>
+#include <xAODAnaHelpers/PhotonDecorator.h>
+#include <xAODAnaHelpers/MuonDecorator.h>
+
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -116,5 +121,9 @@
 #pragma link C++ class Writer+;
 #pragma link C++ class MessagePrinterAlgo+;
 #pragma link C++ class MuonInFatJetCorrector+;
+
+#pragma link C++ class ElectronDecorator+;
+#pragma link C++ class PhotonDecorator+;
+#pragma link C++ class MuonDecorator+;
 
 #endif

--- a/Root/MuonDecorator.cxx
+++ b/Root/MuonDecorator.cxx
@@ -1,0 +1,90 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+#include "xAODMuon/MuonContainer.h"
+#include "xAODEventInfo/EventInfo.h"
+#include "xAODAnaHelpers/HelperFunctions.h"
+#include <xAODAnaHelpers/MuonDecorator.h>
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(MuonDecorator)
+
+MuonDecorator :: MuonDecorator () :
+    Algorithm("MuonDecorator")
+{
+}
+
+EL::StatusCode MuonDecorator :: setupJob (EL::Job& job)
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode MuonDecorator :: histInitialize ()
+{
+
+  ANA_MSG_INFO( m_name );
+  ANA_CHECK( xAH::Algorithm::algInitialize());
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode MuonDecorator :: fileExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode MuonDecorator :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
+
+EL::StatusCode MuonDecorator :: initialize ()
+{
+  ANA_MSG_INFO( "MuonDecorator");
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+  // needed here and not in initalize since this is called first
+  if( m_inContainerName.empty() || m_detailStr.empty() ){
+    ANA_MSG_WARNING( "One or more required configuration values are empty");
+  }
+  ANA_CHECK( m_muonSelectionTool_handle.setProperty( "IsRun3Geo", true ));
+  ANA_CHECK( m_muonSelectionTool_handle.setProperty( "TurnOffMomCorr", true ));
+  ANA_CHECK( m_muonSelectionTool_handle.setProperty( "OutputLevel", msg().level() ));
+  ANA_CHECK( m_muonSelectionTool_handle.retrieve());
+  ANA_MSG_DEBUG("Retrieved tool: " << m_muonSelectionTool_handle);
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode MuonDecorator :: execute ()
+{
+  const xAOD::MuonContainer* Muons(nullptr);
+  if (m_inContainerName.empty()) {
+    ANA_CHECK( HelperFunctions::retrieve(Muons, m_inContainerName, m_event, m_store, msg()) );
+  }
+  // quality decorators
+  static SG::AuxElement::Decorator< char > isVeryLoose("VeryLoose");
+  static SG::AuxElement::Decorator< char > isLoose("Loose");
+  static SG::AuxElement::Decorator< char > isMedium("Medium");
+  static SG::AuxElement::Decorator< char > isTight("Tight");
+  // TODO:: Find out if any ID cuts are applied in the online muon selection
+  // static SG::AuxElement::Decorator< char > passIDcuts("passIDcuts");
+
+  for (const auto& muon : *Muons) {    
+    int this_quality = static_cast<int>( m_muonSelectionTool_handle->getQuality( *muon ) );
+    isVeryLoose( *muon ) = ( this_quality <= static_cast<int>(xAOD::Muon::VeryLoose) ) ? 1 : 0;
+    isLoose( *muon )     = ( this_quality <= static_cast<int>(xAOD::Muon::Loose) )     ? 1 : 0;
+    isMedium( *muon )    = ( this_quality <= static_cast<int>(xAOD::Muon::Medium) )    ? 1 : 0;
+    isTight( *muon )     = ( this_quality <= static_cast<int>(xAOD::Muon::Tight) )     ? 1 : 0;
+    std::cout << "Muon " << muon->index()
+      << " passes VeryLoose: " << isVeryLoose(*muon)
+      << ", Loose: " << isLoose(*muon)
+      << ", Medium: " << isMedium(*muon)
+      << ", Tight: " << isTight(*muon) 
+      << std::endl;
+  }
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode MuonDecorator :: postExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode MuonDecorator :: finalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode MuonDecorator :: histFinalize ()
+{
+  // clean up memory
+  ANA_CHECK( xAH::Algorithm::algFinalize());
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/PhotonDecorator.cxx
+++ b/Root/PhotonDecorator.cxx
@@ -1,0 +1,105 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+#include "xAODEgamma/PhotonContainer.h"
+#include "xAODEventInfo/EventInfo.h"
+#include "xAODAnaHelpers/HelperFunctions.h"
+#include <xAODAnaHelpers/PhotonDecorator.h>
+#include "ElectronPhotonSelectorTools/egammaPIDdefs.h"
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(PhotonDecorator)
+
+PhotonDecorator :: PhotonDecorator () :
+    Algorithm("PhotonDecorator")
+{
+}
+
+EL::StatusCode PhotonDecorator :: setupJob (EL::Job& job)
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode PhotonDecorator :: histInitialize ()
+{
+
+  ANA_MSG_INFO( m_name );
+  ANA_CHECK( xAH::Algorithm::algInitialize());
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode PhotonDecorator :: fileExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode PhotonDecorator :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
+
+EL::StatusCode PhotonDecorator :: initialize ()
+{
+  ANA_MSG_INFO( "PhotonDecorator");
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+  // needed here and not in initalize since this is called first
+  if( m_inContainerName.empty() || m_detailStr.empty() ){
+    ANA_MSG_WARNING( "One or more required configuration values are empty");
+  }
+
+  if (m_photonLooseIsEMSelector.empty()) {
+    m_photonLooseIsEMSelector.setTypeAndName("AsgPhotonIsEMSelector/PhotonLooseIsEMSelector");
+    ANA_CHECK( m_photonLooseIsEMSelector.setProperty("isEMMask", egammaPID::PhotonLoose));
+    ANA_CHECK( m_photonLooseIsEMSelector.setProperty("ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/PhotonIsEMLooseSelectorCutDefs.conf"));
+    ANA_CHECK( m_photonLooseIsEMSelector.setProperty("skipAmbiguityCut", true));
+  }
+  ANA_CHECK( m_photonLooseIsEMSelector.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_photonLooseIsEMSelector);
+  if (m_photonMediumIsEMSelector.empty()) {
+    m_photonMediumIsEMSelector.setTypeAndName("AsgPhotonIsEMSelector/PhotonMediumIsEMSelector");
+    ANA_CHECK( m_photonMediumIsEMSelector.setProperty("isEMMask", egammaPID::PhotonMedium));
+    ANA_CHECK( m_photonMediumIsEMSelector.setProperty("ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/PhotonIsEMMediumSelectorCutDefs.conf"));
+    ANA_CHECK( m_photonMediumIsEMSelector.setProperty("skipAmbiguityCut", true));
+  }
+  ANA_CHECK( m_photonMediumIsEMSelector.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_photonMediumIsEMSelector);
+  if (m_photonTightIsEMSelector.empty()) {
+    m_photonTightIsEMSelector.setTypeAndName("AsgPhotonIsEMSelector/PhotonTightIsEMSelector");
+    ANA_CHECK( m_photonTightIsEMSelector.setProperty("isEMMask", egammaPID::PhotonTight));
+    ANA_CHECK( m_photonTightIsEMSelector.setProperty("ConfigFile", "ElectronPhotonSelectorTools/trigger/rel22_20210611/PhotonIsEMTightSelectorCutDefs.conf"));
+    ANA_CHECK( m_photonTightIsEMSelector.setProperty("skipAmbiguityCut", true));
+  }
+  ANA_CHECK( m_photonTightIsEMSelector.retrieve() );
+  ANA_MSG_DEBUG("Retrieved tool: " << m_photonTightIsEMSelector);
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode PhotonDecorator :: execute ()
+{
+  const xAOD::PhotonContainer* photons(nullptr);
+  if (!m_inContainerName.empty()) {
+    ANA_CHECK( HelperFunctions::retrieve(photons, m_inContainerName, m_event, m_store, msg()) );
+  }
+  for (const auto& photon : *photons) {
+    // quality decorators
+    SG::AuxElement::Decorator< bool > isLoose("PhotonID_Loose");
+    SG::AuxElement::Decorator< bool > isMedium("PhotonID_Medium");
+    SG::AuxElement::Decorator< bool > isTight("PhotonID_Tight");
+
+    isLoose(*photon)  = bool(m_photonLooseIsEMSelector->accept(photon));
+    isMedium(*photon) = bool(m_photonMediumIsEMSelector->accept(photon));
+    isTight(*photon)  = bool(m_photonTightIsEMSelector->accept(photon));
+
+    ANA_MSG_DEBUG("Photon " << photon->index()
+      << " passes Loose: " << isLoose(*photon)
+      << ", Medium: " << isMedium(*photon)
+      << ", Tight: " << isTight(*photon)
+    );
+  }
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode PhotonDecorator :: postExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode PhotonDecorator :: finalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode PhotonDecorator :: histFinalize ()
+{
+  // clean up memory
+  ANA_CHECK( xAH::Algorithm::algFinalize());
+  return EL::StatusCode::SUCCESS;
+}

--- a/data/config_main.py
+++ b/data/config_main.py
@@ -1,0 +1,77 @@
+#adapted from: https://xaodanahelpers.readthedocs.io/en/latest/UsingUs.html
+
+from xAODAnaHelpers import Config
+c = Config()
+
+c.algorithm("BasicEventSelection", {"m_truthLevelOnly": False,
+                                    #"m_applyGRLCut": True,
+                                    #"m_GRLxml": "/cvmfs/atlas.cern.ch/repo/sw/database/GroupData/GoodRunsLists/data24_13p6TeV/20241020/data24_13p6TeV.periodsEtoN_DetStatus-v128-pro36-07_MERGED_PHYS_StandardGRL_All_Good_25ns.xml",
+                                    "m_doPUreweighting": False,
+                                    "m_vertexContainerName": "PrimaryVertices",
+                                    "m_PVNTrack": 2,
+                                    "m_useMetaData": False,
+                                    "m_triggerSelection": "L1_.*|HLT_.*",
+                                    "m_applyTriggerCut": True,
+                                    "m_storeTrigDecisions": True,
+                                    "m_storePassL1": True,
+                                    "m_storePassHLT": True,
+                                    "m_name": "myBaseEventSel"})
+
+c.algorithm("ElectronDecorator", {
+                              "m_name"                      : "ElectronDecor",
+                              #----------------------- Container Flow ----------------------------#
+                              "m_inContainerName"           : "HLT_egamma_Electrons_GSF",
+                              "m_detailStr"                 : "",
+                           }
+)
+
+# c.algorithm("MuonDecorator", {
+#                               "m_name"                      : "MuonDecor",
+#                               #----------------------- Container Flow ----------------------------#
+#                               "m_inContainerName"           : "HLT_Muons_FS",
+#                               "m_detailStr"                 : "",
+#                            }
+# )
+
+c.algorithm("PhotonDecorator", {
+                              "m_name"                      : "PhotonDecor",
+                              #----------------------- Container Flow ----------------------------#
+                              "m_inContainerName"           : "HLT_egamma_Photons",
+                              "m_detailStr"                 : "",
+                           }
+)
+
+c.algorithm("TreeAlgo", {
+                         "m_debug": True,
+                         "m_name": "EB_Tree",
+                         "m_jetContainerName": "HLT_AntiKt4EMPFlowJets_subresjesgscIS_ftf",
+                         "m_jetBranchName": "HLT_jet",
+                         "m_jetDetailStr": "kinematic clean timing energy",
+                         "m_photonContainerName": "HLT_egamma_Photons HLT_egamma_Iso_Photons",
+                         "m_photonBranchName": "HLT_ph HLT_iso_ph",
+                         "m_photonDetailStr": "kinematic PID ISOL_FCLoose ISOL_FCTight",
+                         "m_elContainerName": "HLT_egamma_Electrons_GSF",
+                         "m_elBranchName": "HLT_el",
+                         "m_elDetailStr": "kinematic PID PID_LHVeryLoose PID_LHLoose PID_LHMedium PID_LHTight",
+                         "m_muContainerName": "HLT_Muons_FS",
+                         "m_muBranchName": "HLT_muon",
+                         "m_muDetailStr": "kinematic quality RECO_VeryLoose RECO_Loose RECO_Medium RECO_Tight ",
+			                "m_l1JetContainerName": "L1_jFexSRJetRoI L1_jFexLRJetRoI",
+                         "m_l1JetBranchName": "L1_jFexSRJet L1_jFexLRJet",
+			                "m_TrigMETContainerName": "HLT_MET_nn HLT_MET_cell HLT_MET_tcpufit HLT_MET_pfopufit HLT_MET_mhtpufit_pf HLT_MET_mhtpufit_pf_subjesgscIS",
+                         "m_TrigMETBranchName": "HLT_MET_nn HLT_MET_cell HLT_MET_tcpufit HLT_MET_pfopufit HLT_MET_mhtpufit_pf HLT_MET_mhtpufit_pf_subjesgscIS",
+                         "m_TrigMETDetailStr": "kinematic",
+                         "m_trigDetailStr": "basic passTriggers",
+                         "m_l1MuonContainerName": "LVL1MuonRoIs",
+                         "m_l1MuonBranchName": "L1Muon",
+                         "m_l1TauContainerName": "L1_jFexTauRoI L1_eTauRoI",
+                         "m_l1TauBranchName": "L1Tau_jFex L1Tau_eFex",
+                         "m_l1EMContainerName": "L1_eEMRoI",
+                         "m_l1EMBranchName": "L1Egamma",
+                         "m_l1MetContainerName": "L1_jFexMETRoI",
+                         "m_l1MetDetailStr": "kinematic",
+                         "m_l1MetBranchName": "L1MET",
+			                "m_evtDetailStr": "pileup"
+                         })
+
+

--- a/xAODAnaHelpers/ElectronDecorator.h
+++ b/xAODAnaHelpers/ElectronDecorator.h
@@ -1,0 +1,54 @@
+#ifndef xAODAnaHelpers_ElectronDecorator_H
+#define xAODAnaHelpers_ElectronDecorator_H
+
+// algorithm wrapper
+#include "xAODAnaHelpers/Algorithm.h"
+#include "ElectronPhotonSelectorTools/AsgElectronLikelihoodTool.h"
+
+
+class ElectronDecorator : public xAH::Algorithm
+{
+  // put your configuration variables here as public variables.
+  // that way they can be set directly from CINT and python.
+public:
+  std::string m_inContainerName = "";
+
+  // configuration variables
+  std::string m_detailStr = "";
+
+private:
+
+  // variables that don't get filled at submission time should be
+  // protected from being send from the submission node to the worker
+  // node (done by the //!)
+  asg::AnaToolHandle<AsgElectronLikelihoodTool> m_electronLLHToolVeryLoose{}; //!
+  asg::AnaToolHandle<AsgElectronLikelihoodTool> m_electronLLHToolLoose{}; //!
+  asg::AnaToolHandle<AsgElectronLikelihoodTool> m_electronLLHToolMedium{}; //!
+  asg::AnaToolHandle<AsgElectronLikelihoodTool> m_electronLLHToolTight{}; //!
+
+public:
+  // Tree *myTree; //!
+  // TH1 *myHist; //!
+
+  // this is a standard constructor
+  ElectronDecorator ();
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+
+  /// @cond
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(ElectronDecorator, 1);
+  /// @endcond
+
+};
+
+#endif

--- a/xAODAnaHelpers/MuonDecorator.h
+++ b/xAODAnaHelpers/MuonDecorator.h
@@ -1,0 +1,49 @@
+#ifndef xAODAnaHelpers_MuonDecorator_H
+#define xAODAnaHelpers_MuonDecorator_H
+
+// algorithm wrapper
+#include "xAODAnaHelpers/Algorithm.h"
+#include "MuonAnalysisInterfaces/IMuonSelectionTool.h"
+
+class MuonDecorator : public xAH::Algorithm
+{
+  // put your configuration variables here as public variables.
+  // that way they can be set directly from CINT and python.
+public:
+  std::string m_inContainerName = "";
+
+  // configuration variables
+  std::string m_detailStr = "";
+
+private:
+
+  // variables that don't get filled at submission time should be
+  // protected from being send from the submission node to the worker
+  // node (done by the //!)
+  asg::AnaToolHandle<CP::IMuonSelectionTool> m_muonSelectionTool_handle {"CP::MuonSelectionTool/MuonSelectionTool", this}; //!
+public:
+  // Tree *myTree; //!
+  // TH1 *myHist; //!
+
+  // this is a standard constructor
+  MuonDecorator ();
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+
+  /// @cond
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(MuonDecorator, 1);
+  /// @endcond
+
+};
+
+#endif

--- a/xAODAnaHelpers/PhotonDecorator.h
+++ b/xAODAnaHelpers/PhotonDecorator.h
@@ -1,0 +1,51 @@
+#ifndef xAODAnaHelpers_PhotonDecorator_H
+#define xAODAnaHelpers_PhotonDecorator_H
+
+// algorithm wrapper
+#include "xAODAnaHelpers/Algorithm.h"
+#include "ElectronPhotonSelectorTools/AsgPhotonIsEMSelector.h"
+
+class PhotonDecorator : public xAH::Algorithm
+{
+  // put your configuration variables here as public variables.
+  // that way they can be set directly from CINT and python.
+public:
+  std::string m_inContainerName = "";
+
+  // configuration variables
+  std::string m_detailStr = "";
+
+private:
+
+  // variables that don't get filled at submission time should be
+  // protected from being send from the submission node to the worker
+  // node (done by the //!)
+  asg::AnaToolHandle<AsgPhotonIsEMSelector> m_photonLooseIsEMSelector{}; //!!
+  asg::AnaToolHandle<AsgPhotonIsEMSelector> m_photonMediumIsEMSelector{}; //!!
+  asg::AnaToolHandle<AsgPhotonIsEMSelector> m_photonTightIsEMSelector{}; //!!
+public:
+  // Tree *myTree; //!
+  // TH1 *myHist; //!
+
+  // this is a standard constructor
+  PhotonDecorator ();
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+
+  /// @cond
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(PhotonDecorator, 1);
+  /// @endcond
+
+};
+
+#endif


### PR DESCRIPTION
I have added the functionality to decorate the electron and photon HLT objects with their ID WPs (Loose, Medium, Tight). This runs by calling explicit decoration loops before the main tree algorithm itself runs. I have also added the functionality to add muon WPs, but I haven't been able to make it work yet due to some missing decoration being dereferenced. Will probably have to dig through the HLT code to see what exactly they do. I have also uploaded the `config_main.py` file to make sure we are coherent. In the future, it should be easy to also add isolation WP flags wherever applicable/needed.